### PR TITLE
build: disable CGO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,6 @@ static: deps
 	statik -f -src=./public -dest=server/ -p public
 
 release: static
-	env GOOS=$(GOOS) GOARCH=$(GOARCH) go build -tags release -o $(OUT)
+	env GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -tags release -o $(OUT)
 
 .PHONY: static deps


### PR DESCRIPTION
In container runtime environment, getting error

```
  /lib64/libc.so.6: version `GLIBC_2.32' not found
```